### PR TITLE
[New] Add .irule (F5 TCL impl) as a valid TCL file extension

### DIFF
--- a/Syntaxes/Tcl.plist
+++ b/Syntaxes/Tcl.plist
@@ -8,7 +8,7 @@
 		<string>irule</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>^#!/.*\btclsh\b</string>
+	<string>^#!/.*\btclsh</string>
 	<key>keyEquivalent</key>
 	<string>^~T</string>
 	<key>name</key>

--- a/Syntaxes/Tcl.plist
+++ b/Syntaxes/Tcl.plist
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>tcl</string>
+		<string>irule</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!/.*\btclsh\b</string>


### PR DESCRIPTION
F5's BIG-IP uses TCL to add scripting and ad-hoc capabilities enhancement in their management software. 

This small PR adds the ".irule" file extension to the list of valid TCL file types.